### PR TITLE
Extend redis configuration options with PMEM parameters

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1762,3 +1762,68 @@ rdb-save-incremental-fsync yes
 # Maximum number of set/hash/zset/list fields that will be processed from
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
+
+############################### MEMORY ALLOCATION CONFIGURATION #############################
+#
+# Memory Allocation Policies allow modifying mechanism how heap memory is allocated via zmalloc()
+# function calls. It can target DRAM, Persistent Memory or both. In general, bigger allocations
+# should be stored in Persistent Memory which provides a higher capacity, while smaller and more
+# frequently used should be stored in DRAM.
+# When allocations are to be mixed on both types of memory, this can be defined with:
+#
+# threshold – allocations smaller than the threshold will target DRAM, equal and bigger
+# will target PMEM
+#
+# ratio – the application will be checking DRAM and PMEM utilization ratio and will adopt internal
+# threshold value to reach the defined ratio
+#
+# Redis supports four different Memory Allocation Policies:
+#
+# only-dram: use only DRAM - do not use Persistent Memory
+# only-pmem: use only Persistent Memory - do not use DRAM
+# threshold: use both Persistent Memory and DRAM - use threshold described by static-threshold
+# ratio: use both Persistent Memory and DRAM - use ratio described by dram-pmem-ratio
+#
+# By default Redis use only-dram configuration.
+memory-alloc-policy only-dram
+
+# --- THRESHOLD policy ---
+#
+# HOW IT WORKS?
+#
+# When Threshold policy is selected, application will check static-threshold parameter.
+# Allocation of the size smaller than this threshold goes to DRAM.
+# Allocation of the size equal or bigger than this threshold goes to Persistent Memory.
+# Parameter can be modified when application is running using CONFIG SET.
+#   Note: for static-threshold value equal 64 and typical SET workload with 1kb Strings values
+#         received DRAM:PMEM ratio is around 1:20
+
+# Minimum allocation size measured in bytes which goes to Persistent Memory
+static-threshold 64
+
+# --- RATIO policy ---
+#
+# HOW IT WORKS?
+#
+# Application allocates part of data in DRAM and part in Persistent Memory based on value
+# of internal dynamic threshold and dram-pmem-ratio. Application frequently compares DRAM
+# and Persistent Memory utilization and modifies value of internal dynamic threshold by
+# increasing or decreasing it to achieve expected dram-pmem-ratio. Internal dynamic threshold
+# have have minimum possible limit defined by dynamic-threshold-min.
+
+# The syntax of dram-pmem-ratio directive is the following:
+#
+# dram-pmem-ratio <dram_value> <pmem_value>
+#
+# Expected proportion of memory placement between DRAM and Persistent Memory.
+# Real DRAM:PMEM ratio depends on workload and its variability.
+# dram_value and pmem_value are values from range <1,INT_MAX>
+# In the example below the behavior will be to:
+# Place 25% of all memory in DRAM and 75% in Persistent Memory
+dram-pmem-ratio 1 3
+
+# Initial value of dynamic threshold
+initial-dynamic-threshold 64
+
+# Minimum value of dynamic threshold
+dynamic-threshold-min 24

--- a/src/Makefile
+++ b/src/Makefile
@@ -206,7 +206,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server
 REDIS_SENTINEL_NAME=redis-sentinel
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o gopher.o tracking.o connection.o tls.o sha256.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o gopher.o tracking.o connection.o tls.o sha256.o pmem.o
 REDIS_CLI_NAME=redis-cli
 REDIS_CLI_OBJ=anet.o adlist.o dict.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o siphash.o crc16.o
 REDIS_BENCHMARK_NAME=redis-benchmark

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -1,0 +1,51 @@
+/* pmem.c - Persistent Memory interface
+ *
+ * Copyright (c) 2020, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must start the above copyright notice,
+ *     this quicklist of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this quicklist of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "server.h"
+
+/* Initialize the pmem threshold. */
+void pmemThresholdInit(void)
+{
+    switch(server.memory_alloc_policy) {
+        case MEM_POLICY_ONLY_DRAM:
+            zmalloc_set_threshold(UINT_MAX);
+            break;
+        case MEM_POLICY_ONLY_PMEM:
+            zmalloc_set_threshold(0U);
+            break;
+        case MEM_POLICY_THRESHOLD:
+            zmalloc_set_threshold(server.static_threshold);
+            break;
+        case MEM_POLICY_RATIO:
+            zmalloc_set_threshold(server.initial_dynamic_threshold);
+            break;
+        default:
+            serverAssert(NULL);
+    }
+}

--- a/src/server.c
+++ b/src/server.c
@@ -2885,6 +2885,7 @@ void initServer(void) {
     scriptingInit(1);
     slowlogInit();
     latencyMonitorInit();
+    pmemThresholdInit();
 }
 
 /* Some steps in server initialization need to be done last (after modules

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -83,6 +84,7 @@ void zlibc_free(void *ptr) {
     atomicDecr(used_memory,__n); \
 } while(0)
 
+static size_t pmem_threshold = UINT_MAX;
 static size_t used_memory = 0;
 pthread_mutex_t used_memory_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -225,6 +227,9 @@ size_t zmalloc_used_memory(void) {
 
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t)) {
     zmalloc_oom_handler = oom_handler;
+}
+void zmalloc_set_threshold(size_t threshold) {
+    pmem_threshold = threshold;
 }
 
 /* Get the RSS information in an OS-specific way.

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -92,6 +92,7 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+void zmalloc_set_threshold(size_t threshold);
 
 #ifdef HAVE_DEFRAG
 void zfree_no_tcache(void *ptr);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -94,6 +94,10 @@ start_server {tags {"introspection"}} {
             slaveof
             bind
             requirepass
+            dram-pmem-ratio
+            memory-alloc-policy
+            initial-dynamic-threshold
+            dynamic-threshold-min
         }
 
         set configs {}


### PR DESCRIPTION
- memory-alloc-policy is used to described how/if Persistent Memory is used
- static strategy - pmem-threshold parameter - const threshold from
which alocation goes to PMEM
- dynamic strategy - dram-pmem-ratio parameter - the threshold will be
automatically adjusted to fullfill expected dram-pmem-ratio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/4)
<!-- Reviewable:end -->
