### PR TITLE
Extend configuration parameters for DRAM/PMEM ratio variant

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1809,7 +1809,8 @@ static-threshold 64
 # of internal dynamic threshold and dram-pmem-ratio. Application frequently compares DRAM
 # and Persistent Memory utilization and modifies value of internal dynamic threshold by
 # increasing or decreasing it to achieve expected dram-pmem-ratio. Internal dynamic threshold
-# have have minimum possible limit defined by dynamic-threshold-min.
+# have minimum possible limit defined by dynamic-threshold-min and maximum possible limit
+# defined by dynamic-threshold-max
 
 # The syntax of dram-pmem-ratio directive is the following:
 #
@@ -1827,3 +1828,9 @@ initial-dynamic-threshold 64
 
 # Minimum value of dynamic threshold
 dynamic-threshold-min 24
+
+# Maximum value of dynamic threshold
+dynamic-threshold-max 10000
+
+# DRAM/PMEM ratio period measured in miliseconds
+memory-ratio-check-period 100

--- a/src/server.h
+++ b/src/server.h
@@ -1324,7 +1324,10 @@ struct redisServer {
     unsigned int static_threshold;            /* Persistent Memory static threshold */
     unsigned int initial_dynamic_threshold;   /* Persistent Memory initial dynamic threshold */
     unsigned int dynamic_threshold_min;       /* Minimum value of dynamic threshold */
+    unsigned int dynamic_threshold_max;       /* Maximum value of dynamic threshold */
     ratioDramPmemConfig dram_pmem_ratio;      /* DRAM/Persistent Memory ratio */
+    double target_pmem_dram_ratio;            /* Target PMEM/DRAM ratio */
+    int ratio_check_period;                   /* Period of checking ratio in Cron*/
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -98,6 +98,8 @@ start_server {tags {"introspection"}} {
             memory-alloc-policy
             initial-dynamic-threshold
             dynamic-threshold-min
+            dynamic-threshold-max
+            memory-ratio-check-period
         }
 
         set configs {}


### PR DESCRIPTION
- maximum value of dynamic threshold parameter defined in bytes
- memory ratio check period how often DRAM/PMEM ratio will be checked

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/9)
<!-- Reviewable:end -->
