### PR TITLE
Enable memkind_defrag_reallocate to work on all allocations

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -78,7 +78,7 @@ void* activeDefragAlloc(void *ptr) {
 
 #ifdef HAVE_DEFRAG_MEMKIND
 void* activeDefragAlloc(void *ptr) {
-    void* newptr = memkind_defrag_reallocate(MEMKIND_DEFAULT, ptr);
+    void* newptr = memkind_defrag_reallocate(NULL, ptr);
     if (!newptr) server.stat_active_defrag_misses++;
     return newptr;
 }


### PR DESCRIPTION
- passing NULL allows to run defrag_reallocate on DRAM and PMEM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/14)
<!-- Reviewable:end -->
