### PR TITLE
Add hashtable-on-dram option

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1834,3 +1834,6 @@ dynamic-threshold-max 10000
 
 # DRAM/PMEM ratio period measured in miliseconds
 memory-ratio-check-period 100
+
+# Keep hashtable structure always on DRAM
+hashtable-on-dram yes

--- a/src/config.c
+++ b/src/config.c
@@ -2160,6 +2160,7 @@ standardConfig configs[] = {
     createBoolConfig("cluster-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_enabled, 0, NULL, NULL),
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, server.aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
+    createBoolConfig("hashtable-on-dram", NULL, IMMUTABLE_CONFIG, server.hashtable_on_dram, 1, NULL, NULL),
 
 
     /* String Configs */

--- a/src/dict.c
+++ b/src/dict.c
@@ -61,6 +61,7 @@
  * the number of elements and the buckets > dict_force_resize_ratio. */
 static int dict_can_resize = 1;
 static unsigned int dict_force_resize_ratio = 5;
+static int dict_always_on_dram = 1;
 
 /* -------------------------- private prototypes ---------------------------- */
 
@@ -79,6 +80,10 @@ void dictSetHashFunctionSeed(uint8_t *seed) {
 
 uint8_t *dictGetHashFunctionSeed(void) {
     return dict_hash_function_seed;
+}
+
+void dictSetAllocPolicy(int policy) {
+    dict_always_on_dram = policy;
 }
 
 /* The default hashing function uses SipHash implementation
@@ -160,7 +165,7 @@ int dictExpand(dict *d, unsigned long size)
     /* Allocate the new hash table and initialize all pointers to NULL */
     n.size = realsize;
     n.sizemask = realsize-1;
-    n.table = zcalloc_dram(realsize*sizeof(dictEntry*));
+    n.table = (dict_always_on_dram) ? zcalloc_dram(realsize*sizeof(dictEntry*)) : zcalloc(realsize*sizeof(dictEntry*));
     n.used = 0;
 
     /* Is this the first initialization? If so it's not really a rehashing
@@ -219,7 +224,7 @@ int dictRehash(dict *d, int n) {
 
     /* Check if we already rehashed the whole table... */
     if (d->ht[0].used == 0) {
-        zfree_dram(d->ht[0].table);
+        zfree(d->ht[0].table);
         d->ht[0] = d->ht[1];
         _dictReset(&d->ht[1]);
         d->rehashidx = -1;
@@ -459,7 +464,7 @@ int _dictClear(dict *d, dictht *ht, void(callback)(void *)) {
         }
     }
     /* Free the table and the allocated cache structure */
-    zfree_dram(ht->table);
+    zfree(ht->table);
     /* Re-initialize the table */
     _dictReset(ht);
     return DICT_OK; /* never fails */

--- a/src/dict.h
+++ b/src/dict.h
@@ -178,6 +178,7 @@ int dictRehash(dict *d, int n);
 int dictRehashMilliseconds(dict *d, int ms);
 void dictSetHashFunctionSeed(uint8_t *seed);
 uint8_t *dictGetHashFunctionSeed(void);
+void dictSetAllocPolicy(int policy);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, dictScanBucketFunction *bucketfn, void *privdata);
 uint64_t dictGetHash(dict *d, const void *key);
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t hash);

--- a/src/server.c
+++ b/src/server.c
@@ -2889,6 +2889,7 @@ void initServer(void) {
     slowlogInit();
     latencyMonitorInit();
     pmemThresholdInit();
+    dictSetAllocPolicy(server.hashtable_on_dram);
 }
 
 /* Some steps in server initialization need to be done last (after modules

--- a/src/server.h
+++ b/src/server.h
@@ -1328,6 +1328,7 @@ struct redisServer {
     ratioDramPmemConfig dram_pmem_ratio;      /* DRAM/Persistent Memory ratio */
     double target_pmem_dram_ratio;            /* Target PMEM/DRAM ratio */
     int ratio_check_period;                   /* Period of checking ratio in Cron*/
+    int hashtable_on_dram;                    /* Keep hashtable always on DRAM */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -100,6 +100,7 @@ start_server {tags {"introspection"}} {
             dynamic-threshold-min
             dynamic-threshold-max
             memory-ratio-check-period
+            hashtable-on-dram
         }
 
         set configs {}


### PR DESCRIPTION
- set to no to keep expected dram-pmem ratio for small object size e.g.
32 bytes for 1:16 ratio
- restore generic zfree mechanism in dict module - Hashtable is
initialized before reading config - so it could be on dram or pmem,
despite the selected hashtable-on-dram option

Co-authored-by: jschmieg <jakub.schmiegel@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/17)
<!-- Reviewable:end -->
