### PR TITLE
Fix missing default param

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1521,6 +1521,12 @@ void initServerConfig(void) {
     server.notify_keyspace_events = 0;
     server.maxclients = CONFIG_DEFAULT_MAX_CLIENTS;
     server.hashtable_on_dram = 1;
+    server.memory_alloc_policy = MEM_POLICY_ONLY_DRAM;
+    server.ratio_check_period = 100;
+    server.initial_dynamic_threshold = 64;
+    server.dynamic_threshold_min = 24;
+    server.dynamic_threshold_max = 10000;
+    server.static_threshold = 64;
     server.bpop_blocked_clients = 0;
     server.maxmemory = CONFIG_DEFAULT_MAXMEMORY;
     server.maxmemory_policy = CONFIG_DEFAULT_MAXMEMORY_POLICY;


### PR DESCRIPTION
Add default value for config parameters:
- values will be used in e.g. calling ./redis-server (without passing
redis.conf) or when the parameter is not present in passed redis.conf

Rebased now ready to merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/21)
<!-- Reviewable:end -->
