### PR TITLE
Adjust internal threshold on RDB loading

### DIFF
--- a/src/pmem.c
+++ b/src/pmem.c
@@ -62,38 +62,37 @@ void pmemThresholdInit(void) {
 }
 
 void adjustPmemThresholdCycle(void) {
-    if (server.memory_alloc_policy == MEM_POLICY_RATIO) {
-        run_with_period(server.ratio_check_period) {
-            /* Difference between target ratio and current ratio in last checkpoint*/
-            static double ratio_diff_checkpoint;
-            /* PMEM and DRAM utilization in last checkpoint*/
-            static size_t total_memory_checkpoint;
-            size_t pmem_memory = zmalloc_used_pmem_memory();
-            size_t dram_memory = zmalloc_used_memory();
-            size_t total_memory_current = pmem_memory + dram_memory;
-            // do not modify threshold when change in memory usage is too small
-            if (absDiff(total_memory_checkpoint, total_memory_current) > 100) {
-                double current_ratio = (double)pmem_memory/dram_memory;
-                double current_ratio_diff = fabs(current_ratio - server.target_pmem_dram_ratio);
-                if (current_ratio_diff > 0.02) {
-                    //current ratio is worse than moment before
-                    double variableMultipler = current_ratio/server.target_pmem_dram_ratio;
-                    double step = (current_ratio_diff < ratio_diff_checkpoint) ?
-                                  variableMultipler*THRESHOLD_STEP_NORMAL : variableMultipler*THRESHOLD_STEP_AGGRESIVE;
-                    size_t threshold = zmalloc_get_threshold();
-                    if (server.target_pmem_dram_ratio < current_ratio) {
-                        size_t higher_threshold = THRESHOLD_UP(threshold,step);
-                        if (higher_threshold <= server.dynamic_threshold_max)
-                            zmalloc_set_threshold(higher_threshold);
-                    } else {
-                        size_t lower_threshold = THRESHOLD_DOWN(threshold,step);
-                        if (lower_threshold >= server.dynamic_threshold_min)
-                            zmalloc_set_threshold(lower_threshold);
-                    }
-                }
-                ratio_diff_checkpoint = current_ratio_diff;
-            }
-            total_memory_checkpoint = total_memory_current;
-        }
+    if (server.memory_alloc_policy != MEM_POLICY_RATIO) {
+        return;
     }
+    /* Difference between target ratio and current ratio in last checkpoint*/
+    static double ratio_diff_checkpoint;
+    /* PMEM and DRAM utilization in last checkpoint*/
+    static size_t total_memory_checkpoint;
+    size_t pmem_memory = zmalloc_used_pmem_memory();
+    size_t dram_memory = zmalloc_used_memory();
+    size_t total_memory_current = pmem_memory + dram_memory;
+    // do not modify threshold when change in memory usage is too small
+    if (absDiff(total_memory_checkpoint, total_memory_current) > 100) {
+        double current_ratio = (double)pmem_memory/dram_memory;
+        double current_ratio_diff = fabs(current_ratio - server.target_pmem_dram_ratio);
+        if (current_ratio_diff > 0.02) {
+            //current ratio is worse than moment before
+            double variableMultipler = current_ratio/server.target_pmem_dram_ratio;
+            double step = (current_ratio_diff < ratio_diff_checkpoint) ?
+                          variableMultipler*THRESHOLD_STEP_NORMAL : variableMultipler*THRESHOLD_STEP_AGGRESIVE;
+            size_t threshold = zmalloc_get_threshold();
+            if (server.target_pmem_dram_ratio < current_ratio) {
+                size_t higher_threshold = THRESHOLD_UP(threshold,step);
+                if (higher_threshold <= server.dynamic_threshold_max)
+                    zmalloc_set_threshold(higher_threshold);
+            } else {
+                size_t lower_threshold = THRESHOLD_DOWN(threshold,step);
+                if (lower_threshold >= server.dynamic_threshold_min)
+                    zmalloc_set_threshold(lower_threshold);
+            }
+        }
+        ratio_diff_checkpoint = current_ratio_diff;
+    }
+    total_memory_checkpoint = total_memory_current;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1442,6 +1442,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
 
         /* Load every single element of the list */
         while(len--) {
+            if (len%100) {
+                adjustPmemThresholdCycle();
+            }
             if ((ele = rdbLoadEncodedStringObject(rdb)) == NULL) {
                 decrRefCount(o);
                 return NULL;
@@ -1471,6 +1474,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
         for (i = 0; i < len; i++) {
             long long llval;
             sds sdsele;
+
+            if (i%100) {
+                adjustPmemThresholdCycle();
+            }
 
             if ((sdsele = rdbGenericLoadStringObject(rdb,RDB_LOAD_SDS,NULL)) == NULL) {
                 decrRefCount(o);
@@ -1513,6 +1520,10 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
             sds sdsele;
             double score;
             zskiplistNode *znode;
+
+            if (zsetlen%100) {
+                adjustPmemThresholdCycle();
+            }
 
             if ((sdsele = rdbGenericLoadStringObject(rdb,RDB_LOAD_SDS,NULL)) == NULL) {
                 decrRefCount(o);
@@ -1561,6 +1572,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
         /* Load every field and value into the ziplist */
         while (o->encoding == OBJ_ENCODING_ZIPLIST && len > 0) {
             len--;
+
+            if (len%100) {
+                adjustPmemThresholdCycle();
+            }
+
             /* Load raw strings */
             if ((field = rdbGenericLoadStringObject(rdb,RDB_LOAD_SDS,NULL)) == NULL) {
                 decrRefCount(o);
@@ -1624,6 +1640,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
                             server.list_compress_depth);
 
         while (len--) {
+            if (len%100) {
+                adjustPmemThresholdCycle();
+            }
             unsigned char *zl =
                 rdbGenericLoadStringObject(rdb,RDB_LOAD_PLAIN,NULL);
             if (zl == NULL) {
@@ -2053,6 +2072,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
     int type, rdbver;
     redisDb *db = server.db+0;
     char buf[1024];
+    int i=0;
 
     rdb->update_cksum = rdbLoadProgressCallback;
     rdb->max_processing_chunk = server.loading_process_events_interval_bytes;
@@ -2077,7 +2097,11 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
     while(1) {
         sds key;
         robj *val;
-
+        i++;
+        if (i%1000) {
+            i=0;
+            adjustPmemThresholdCycle();
+        }
         /* Read type. */
         if ((type = rdbLoadType(rdb)) == -1) goto eoferr;
 

--- a/src/server.c
+++ b/src/server.c
@@ -1698,8 +1698,11 @@ void databasesCron(void) {
     }
 
     /* Adjust PMEM threshold. */
-    adjustPmemThresholdCycle();
-
+    if (server.memory_alloc_policy == MEM_POLICY_RATIO) {
+        run_with_period(server.ratio_check_period) {
+            adjustPmemThresholdCycle();
+        }
+    }
     /* Defrag keys gradually. */
     activeDefragCycle();
 


### PR DESCRIPTION
RDB loading with DRAM/PMEM threshold adjustment.
For proper working with Ziplist (node size by default is 8k), use the higher value of:
_dynamic-threshold-max_ in redis,conf.
e.g.:
_# Maximum value of dynamic threshold
dynamic-threshold-max 20000_
Tested for LPUSH, SET and SADD.
Fixes #31 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/32)
<!-- Reviewable:end -->
