### PR TITLE
Optimize cache miss in SDS free to improve overall performance (mostly MSET scenario)

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -281,6 +281,12 @@ robj *createModuleObject(moduleType *mt, void *value) {
     return createObject(OBJ_MODULE,mv);
 }
 
+void freeStringObjectOptim(robj *o) {
+    if (o->encoding == OBJ_ENCODING_RAW) {
+        sdsfreeOptim(o->ptr);
+    }
+}
+
 void freeStringObject(robj *o) {
     if (o->encoding == OBJ_ENCODING_RAW) {
         sdsfree(o->ptr);
@@ -364,7 +370,7 @@ void incrRefCount(robj *o) {
 static void _decrRefCount(robj *o, int on_dram) {
     if (o->refcount == 1) {
         switch(o->type) {
-        case OBJ_STRING: freeStringObject(o); break;
+        case OBJ_STRING: freeStringObjectOptim(o); break;
         case OBJ_LIST: freeListObject(o); break;
         case OBJ_SET: freeSetObject(o); break;
         case OBJ_ZSET: freeZsetObject(o); break;

--- a/src/sds.h
+++ b/src/sds.h
@@ -64,12 +64,14 @@ struct __attribute__ ((__packed__)) sdshdr32 {
     uint32_t len; /* used */
     uint32_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char padding; /* Added to have unique value for %8 operation*/
     char buf[];
 };
 struct __attribute__ ((__packed__)) sdshdr64 {
     uint64_t len; /* used */
     uint64_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char padding[3]; /* Added to have unique value for %8 operation */
     char buf[];
 };
 
@@ -83,6 +85,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
+#define SDS_MOD8(T) (sizeof(struct sdshdr##T)&7)
 
 static inline size_t sdslen(const sds s) {
     unsigned char flags = s[-1];
@@ -221,6 +224,7 @@ sds sdsempty(void);
 sds sdsdramempty(void);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
+void sdsfreeOptim(sds s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);
 sds sdscat(sds s, const char *t);

--- a/src/server.h
+++ b/src/server.h
@@ -1756,6 +1756,7 @@ void incrRefCount(robj *o);
 robj *makeObjectShared(robj *o);
 robj *resetRefCount(robj *obj);
 void freeStringObject(robj *o);
+void freeStringObjectOptim(robj *o);
 void freeListObject(robj *o);
 void freeSetObject(robj *o);
 void freeZsetObject(robj *o);


### PR DESCRIPTION
Eliminates cache-miss on calling free() on SDS bigger then Embedded String. 
In the previous implementation to calculate the address of allocation of SDS object during free() it was needed to access the SDS header to find the length of the prefix. It generated cache-miss.
In current implementation access to SDS header is not needed. SdsHdrSize is retrieved from calculating 'modulo 8' operation on SDS pointer. To have unique values of 'modulo 8' operation on different header size it was needed to add padding in 2 Sds Headers (sdshdr32 and sdshdr64).
Important: if this modification will be used with Rdb files generated on previous versions AND Rdb file contains such SDS (only Strings longer than 32kb) then this may not be compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/47)
<!-- Reviewable:end -->
