### PR TITLE
Correct memory usage statistic with sum of DRAM and PMEM

### DIFF
--- a/src/pmem.c
+++ b/src/pmem.c
@@ -70,7 +70,7 @@ void adjustPmemThresholdCycle(void) {
     /* PMEM and DRAM utilization in last checkpoint*/
     static size_t total_memory_checkpoint;
     size_t pmem_memory = zmalloc_used_pmem_memory();
-    size_t dram_memory = zmalloc_used_memory();
+    size_t dram_memory = zmalloc_used_dram_memory();
     size_t total_memory_current = pmem_memory + dram_memory;
     // do not modify threshold when change in memory usage is too small
     if (absDiff(total_memory_checkpoint, total_memory_current) > 100) {

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -94,6 +94,7 @@ void zfree_dram(void *ptr);
 char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 size_t zmalloc_used_pmem_memory(void);
+size_t zmalloc_used_dram_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident);


### PR DESCRIPTION
Corrects #61 
Now used_memory and used_memory_human in INFO MEMORY will display SUM of DRAM and PMEM used memory.
For DRAM used memory I propose to add separate statistics (not in this PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/62)
<!-- Reviewable:end -->
