### PR TITLE
Add --pmem-ratio option for runtest

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -17,6 +17,7 @@ source ../support/test.tcl
 
 set ::verbose 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::tls 0
 set ::pause_on_error 0
 set ::dont_clean 0
@@ -230,6 +231,8 @@ proc parse_options {} {
             set ::simulate_error 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
+        } elseif {$opt eq {--pmem-ratio}} {
+            set ::pmem_ratio_test 1
         } elseif {$opt eq {--tls}} {
             package require tls 1.6
             ::tls::init \
@@ -243,6 +246,7 @@ proc parse_options {} {
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
             puts "--valgrind              Run with valgrind."
+            puts "--pmem-ratio            Run the tests with pmem-ratio variant."
             puts "--tls                   Run tests in TLS mode."
             puts "--help                  Shows this help."
             exit 0

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -228,6 +228,15 @@ proc wait_server_started {config_file stdout pid} {
 proc start_server {options {code undefined}} {
     # setup defaults
     set baseconfig "default.conf"
+    if {$::pmem_ratio_test} {
+        set memory-alloc-policy "ratio"
+        set dram-pmem-ratio "1 3"
+        set initial-dynamic-threshold "64"
+        set dynamic-threshold-min "24"
+        set dynamic-threshold-max "10000"
+        set memory-ratio-check-period "100"
+        set hashtable-on-dram "yes"
+    }
     set overrides {}
     set tags {}
     set keep_persistence false

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -80,6 +80,7 @@ set ::baseport 21111; # initial port for spawned redis servers
 set ::portcount 8000; # we don't wanna use more than 10000 to avoid collision with cluster bus ports
 set ::traceleaks 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::durable 0
 set ::tls 0
 set ::stack_logging 0
@@ -524,6 +525,7 @@ proc send_data_packet {fd status data} {
 proc print_help_screen {} {
     puts [join {
         "--valgrind         Run the test over valgrind."
+        "--pmem-ratio       Run the tests with pmem-ratio variant."
         "--durable          suppress test crashes and keep running"
         "--stack-logging    Enable OSX leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
@@ -583,6 +585,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         incr j
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
+    } elseif {$opt eq {--pmem-ratio}} {
+        set ::pmem_ratio_test 1
     } elseif {$opt eq {--stack-logging}} {
         if {[string match {*Darwin*} [exec uname -a]]} {
             set ::stack_logging 1


### PR DESCRIPTION
- to test ratio configuration run: ./runtest --pmem-ratio
- allows to run test for configuration including ratio policy
- update default.conf with following values:
    memory-alloc-policy ratio
    dram-pmem-ratio 1 3
    initial-dynamic-threshold 64
    memory-ratio-check-period 100
    hashtable-on-dram yes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/65)
<!-- Reviewable:end -->
