### PR TITLE
[6.0.9]Optimize support for memory-alloc-policy only-dram

### DIFF
--- a/src/pmem.c
+++ b/src/pmem.c
@@ -49,12 +49,15 @@ void pmemThresholdInit(void) {
             break;
         case MEM_POLICY_ONLY_PMEM:
             zmalloc_set_threshold(0U);
+            zmalloc_set_pmem_mode();
             break;
         case MEM_POLICY_THRESHOLD:
             zmalloc_set_threshold(server.static_threshold);
+            zmalloc_set_pmem_mode();
             break;
         case MEM_POLICY_RATIO:
             zmalloc_set_threshold(server.initial_dynamic_threshold);
+            zmalloc_set_pmem_mode();
             break;
         default:
             serverAssert(NULL);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -60,6 +60,9 @@ void zlibc_free(void *ptr) {
 #define DRAM_LOCATION 0
 #define PMEM_LOCATION 1
 
+#define MEMORY_ONLY_DRAM 0
+#define MEMORY_DRAM_PMEM 1
+
 /* Explicitly override malloc/free etc when using tcmalloc. */
 #if defined(USE_TCMALLOC)
 #define malloc(size) tc_malloc(size)
@@ -150,6 +153,7 @@ size_t zmalloc_used_memory(void) {
     atomicDecr(used_pmem_memory,__n); \
 } while(0)
 
+static int memory_variant = MEMORY_ONLY_DRAM;
 static size_t pmem_threshold = UINT_MAX;
 static size_t used_dram_memory = 0;
 static size_t used_pmem_memory = 0;
@@ -184,6 +188,7 @@ void *zmalloc_dram(size_t size) {
 
 #ifdef USE_MEMKIND
 static int zmalloc_is_pmem(void * ptr) {
+    if (memory_variant == MEMORY_ONLY_DRAM) return DRAM_LOCATION;
     struct memkind *temp_kind = memkind_detect_kind(ptr);
     return (temp_kind == MEMKIND_DEFAULT) ? DRAM_LOCATION : PMEM_LOCATION;
 }
@@ -422,6 +427,10 @@ size_t zmalloc_get_threshold(void) {
 
 void zmalloc_set_threshold(size_t threshold) {
     pmem_threshold = threshold;
+}
+
+void zmalloc_set_pmem_mode(void) {
+    memory_variant = MEMORY_DRAM_PMEM;
 }
 
 /* Get the RSS information in an OS-specific way.

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -105,6 +105,7 @@ size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zmalloc_set_threshold(size_t threshold);
+void zmalloc_set_pmem_mode(void);
 size_t zmalloc_get_threshold(void);
 void *zmalloc_dram(size_t size);
 void *zcalloc_dram(size_t size);


### PR DESCRIPTION
- limit memkind detect_kind operation for "only-dram" variant
- set information about used memory(DRAM or DRAM+PMEM) after startup
- during free operation, check if the currently used configuration works
  as "only-dram" - quick fallback if yes
- this will avoid unnecessary jemalloc call for looking correct memory kind

Co-authored-by: jschmieg <jakub.schmiegel@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/84)
<!-- Reviewable:end -->
