### PR TITLE
[5.0.0]Optimize support for memory-alloc-policy only-dram

### DIFF
--- a/src/pmem.c
+++ b/src/pmem.c
@@ -49,12 +49,15 @@ void pmemThresholdInit(void) {
             break;
         case MEM_POLICY_ONLY_PMEM:
             zmalloc_set_threshold(0U);
+            zmalloc_set_pmem_mode();
             break;
         case MEM_POLICY_THRESHOLD:
             zmalloc_set_threshold(server.static_threshold);
+            zmalloc_set_pmem_mode();
             break;
         case MEM_POLICY_RATIO:
             zmalloc_set_threshold(server.initial_dynamic_threshold);
+            zmalloc_set_pmem_mode();
             break;
         default:
             serverAssert(NULL);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -103,6 +103,7 @@ size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zmalloc_set_threshold(size_t threshold);
+void zmalloc_set_pmem_mode(void);
 size_t zmalloc_get_threshold(void);
 void *zmalloc_dram(size_t size);
 void *zcalloc_dram(size_t size);


### PR DESCRIPTION
- limit memkind detect_kind operation for "only-dram" variant
- set information about used memory(DRAM or DRAM+PMEM) after startup
- during free operation, check if the currently used configuration works
  as "only-dram" - quick fallback if yes
- this will avoid unnecessary jemalloc call for looking correct memory kind

Co-authored-by: jschmieg <jakub.schmiegel@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/90)
<!-- Reviewable:end -->
