### PR TITLE
[6.0.0] Update GitHub Actions 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,28 +4,42 @@ on: [push, pull_request]
 
 jobs:
   test-ubuntu-latest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    name: Allocator ${{ matrix.allocator }} | Compiler ${{ matrix.env.cc }}
+    strategy:
+      matrix:
+        env:
+          - { cc: gcc, cxx: g++}
+          - { cc: clang, cxx: clang++}
+        allocator: [jemalloc, libc, memkind]
     steps:
-    - uses: actions/checkout@v1
-    - name: make
-      run: make
-    - name: test
+
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install memkind build dependencies
       run: |
-        sudo apt-get install tcl8.5
-        ./runtest --verbose
-    - name: module api test
-      run: ./runtest-moduleapi --verbose
+          if [ "${{ matrix.allocator }}" == memkind ]; then
+            sudo apt install libjson-c-dev libkeyutils-dev libkmod-dev libnuma-dev libudev-dev uuid-dev
+            wget https://github.com/pmem/ndctl/archive/v68.tar.gz
+            tar -xzvf v68.tar.gz
+            pushd ndctl-68 && ./autogen.sh && ./configure --disable-docs --prefix=/usr && make && sudo make install && popd
+          fi
 
-  build-ubuntu-old:
-    runs-on: ubuntu-16.04
-    steps:
-    - uses: actions/checkout@v1
-    - name: make
-      run: make
+    - name: Install test dependencies
+      run: sudo apt install tcl
 
-  build-macos-latest:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: make
-      run: make
+    - name: Build memKeydB
+      run: make gcov MALLOC=${{ matrix.allocator }}
+
+    - name: Run Tests
+      run: |
+          if [ "${{ matrix.allocator }}" == memkind ]; then
+            MEMKIND_DAX_KMEM_NODES=0 ./runtest --pmem-ratio --clients 1
+          fi
+          ./runtest --clients 1
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -17,6 +17,7 @@ source ../support/test.tcl
 
 set ::verbose 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::tls 0
 set ::pause_on_error 0
 set ::simulate_error 0
@@ -161,6 +162,8 @@ proc parse_options {} {
             set ::simulate_error 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
+        } elseif {$opt eq {--pmem-ratio}} {
+            set ::pmem_ratio_test 1
         } elseif {$opt eq {--tls}} {
             package require tls 1.6
             ::tls::init \
@@ -175,6 +178,7 @@ proc parse_options {} {
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
             puts "--valgrind              Run with valgrind."
+            puts "--pmem-ratio            Run the tests with pmem-ratio variant."
             puts "--help                  Shows this help."
             exit 0
         } else {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -174,6 +174,15 @@ proc start_server {options {code undefined}} {
 
     # setup defaults
     set baseconfig "default.conf"
+    if {$::pmem_ratio_test} {
+        set memory-alloc-policy "ratio"
+        set dram-pmem-ratio "1 3"
+        set initial-dynamic-threshold "64"
+        set dynamic-threshold-min "24"
+        set dynamic-threshold-max "10000"
+        set memory-ratio-check-period "100"
+        set hashtable-on-dram "yes"
+    }
     set overrides {}
     set tags {}
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -73,6 +73,7 @@ set ::host 127.0.0.1
 set ::port 21111
 set ::traceleaks 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::tls 0
 set ::stack_logging 0
 set ::verbose 0
@@ -496,6 +497,7 @@ proc send_data_packet {fd status data} {
 proc print_help_screen {} {
     puts [join {
         "--valgrind         Run the test over valgrind."
+        "--pmem-ratio       Run the tests with pmem-ratio variant."
         "--stack-logging    Enable OSX leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
@@ -543,6 +545,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::skiptests [split $file_data "\n"]
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
+    } elseif {$opt eq {--pmem-ratio}} {
+        set ::pmem_ratio_test 1
     } elseif {$opt eq {--stack-logging}} {
         if {[string match {*Darwin*} [exec uname -a]]} {
             set ::stack_logging 1


### PR DESCRIPTION
1. GitHub Actions

provide building and testing memKeydB with the following configuration
compiler: clang/gcc
allocator: jemalloc/glibc/memkind

2. Extend Runtest option

Add --pmem-ratio option for runtest
- to test ratio configuration run: ./runtest --pmem-ratio
- allows to run test for configuration including ratio policy
- update default.conf with following values:
    memory-alloc-policy ratio
    dram-pmem-ratio 1 3
    initial-dynamic-threshold 64
    memory-ratio-check-period 100
    hashtable-on-dram yes

3. Revert an optimization that causes a crash due to a bug in the code
For details see:
https://github.com/redis/redis/blob/47ff13637e1254e5a6ac962afa3e963d2f284783/00-RELEASENOTES#L21-L26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/102)
<!-- Reviewable:end -->
