### PR TITLE
[5.0.2] Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+
+  test-ubuntu-latest:
+    runs-on: ubuntu-20.04
+    name: Allocator ${{ matrix.allocator }} | Compiler ${{ matrix.env.cc }}
+    strategy:
+      matrix:
+        env:
+          - { cc: gcc, cxx: g++}
+          - { cc: clang, cxx: clang++}
+        allocator: [jemalloc, libc, memkind]
+    steps:
+
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install memkind build dependencies
+      run: |
+          if [ "${{ matrix.allocator }}" == memkind ]; then
+            sudo apt install libjson-c-dev libkeyutils-dev libkmod-dev libnuma-dev libudev-dev uuid-dev
+            wget https://github.com/pmem/ndctl/archive/v68.tar.gz
+            tar -xzvf v68.tar.gz
+            pushd ndctl-68 && ./autogen.sh && ./configure --disable-docs --prefix=/usr && make && sudo make install && popd
+          fi
+
+    - name: Install test dependencies
+      run: sudo apt install tcl
+
+    - name: Build memKeydB
+      run: make gcov MALLOC=${{ matrix.allocator }}
+
+    - name: Run Tests
+      run: |
+          if [ "${{ matrix.allocator }}" == memkind ]; then
+            MEMKIND_DAX_KMEM_NODES=0 ./runtest --pmem-ratio --clients 1
+          fi
+          ./runtest --clients 1
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -17,6 +17,7 @@ source ../support/test.tcl
 
 set ::verbose 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::pause_on_error 0
 set ::simulate_error 0
 set ::failed 0
@@ -148,6 +149,8 @@ proc parse_options {} {
             set ::simulate_error 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
+        } elseif {$opt eq {--pmem-ratio}} {
+            set ::pmem_ratio_test 1
         } elseif {$opt eq "--help"} {
             puts "Hello, I'm sentinel.tcl and I run Sentinel unit tests."
             puts "\nOptions:"
@@ -155,6 +158,7 @@ proc parse_options {} {
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
             puts "--valgrind              Run with valgrind."
+            puts "--pmem-ratio            Run the tests with pmem-ratio variant."
             puts "--help                  Shows this help."
             exit 0
         } else {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -158,6 +158,15 @@ proc start_server {options {code undefined}} {
 
     # setup defaults
     set baseconfig "default.conf"
+    if {$::pmem_ratio_test} {
+        set memory-alloc-policy "ratio"
+        set dram-pmem-ratio "1 3"
+        set initial-dynamic-threshold "64"
+        set dynamic-threshold-min "24"
+        set dynamic-threshold-max "10000"
+        set memory-ratio-check-period "100"
+        set hashtable-on-dram "yes"
+    }
     set overrides {}
     set tags {}
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -44,7 +44,6 @@ set ::all_tests {
     integration/rdb
     integration/convert-zipmap-hash-on-load
     integration/logging
-    integration/psync2
     integration/psync2-reg
     unit/pubsub
     unit/slowlog

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -70,6 +70,7 @@ set ::host 127.0.0.1
 set ::port 21111
 set ::traceleaks 0
 set ::valgrind 0
+set ::pmem_ratio_test 0
 set ::stack_logging 0
 set ::verbose 0
 set ::quiet 0
@@ -433,6 +434,7 @@ proc send_data_packet {fd status data} {
 proc print_help_screen {} {
     puts [join {
         "--valgrind         Run the test over valgrind."
+        "--pmem-ratio       Run the tests with pmem-ratio variant."
         "--stack-logging    Enable OSX leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
@@ -479,6 +481,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::skiptests [split $file_data "\n"]
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
+    } elseif {$opt eq {--pmem-ratio}} {
+        set ::pmem_ratio_test 1
     } elseif {$opt eq {--stack-logging}} {
         if {[string match {*Darwin*} [exec uname -a]]} {
             set ::stack_logging 1


### PR DESCRIPTION
1. GitHub Actions
provide building and testing memKeydB with the following configuration
compiler: clang/gcc
allocator: jemalloc/glibc/memkind

2. Extend Runtest option
Add --pmem-ratio option for runtest

to test ratio configuration run: ./runtest --pmem-ratio
allows to run test for configuration including ratio policy
update default.conf with following values:
memory-alloc-policy ratio
dram-pmem-ratio 1 3
initial-dynamic-threshold 64
memory-ratio-check-period 100
hashtable-on-dram yes

3. Exclude psync2 test - integration/psync2 also fails in original redis tag

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/107)
<!-- Reviewable:end -->
