### PR TITLE
[5.0.2] Handle the allocation for only-dram variant

### DIFF
--- a/src/pmem.c
+++ b/src/pmem.c
@@ -45,7 +45,7 @@ static inline size_t absDiff(size_t a, size_t b) {
 void pmemThresholdInit(void) {
     switch(server.memory_alloc_policy) {
         case MEM_POLICY_ONLY_DRAM:
-            zmalloc_set_threshold(UINT_MAX);
+            zmalloc_set_threshold(SIZE_MAX);
             break;
         case MEM_POLICY_ONLY_PMEM:
             zmalloc_set_threshold(0U);


### PR DESCRIPTION
- fix maximum threshold for SIZE_MAX to handle all the allocations
- this commit fix issue for the configuration with: only-dram variant and memkind allocator:
  when the threshold reaches a value above 4294967295 bytes, zmalloc call results with calling
  zmalloc_pmem and returning NULL on the platform without PMEM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/117)
<!-- Reviewable:end -->
