### PR TITLE
[5.0.2] Optimize DRAM allocations

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -78,11 +78,16 @@ void zlibc_free(void *ptr) {
 #define dallocx(ptr,flags) je_dallocx(ptr,flags)
 #elif defined(USE_MEMKIND)
 #include <errno.h>
-#define malloc(size) memkind_malloc(MEMKIND_DEFAULT,size)
-#define calloc(count,size) memkind_calloc(MEMKIND_DEFAULT,count,size)
-#define realloc_dram(ptr,size) memkind_realloc(MEMKIND_DEFAULT,ptr,size)
+extern void* jemk_malloc(size_t size);
+extern void* jemk_calloc(size_t count, size_t size);
+extern void* jemk_realloc(void* ptr, size_t size);
+extern void jemk_free(void* ptr);
+
+#define malloc(size) jemk_malloc(size);
+#define calloc(count,size) jemk_calloc(count,size)
+#define realloc_dram(ptr,size) jemk_realloc(ptr,size)
 #define realloc_pmem(ptr,size) memkind_realloc(MEMKIND_DAX_KMEM,ptr,size)
-#define free_dram(ptr) memkind_free(MEMKIND_DEFAULT,ptr)
+#define free_dram(ptr) jemk_free(ptr)
 #define free_pmem(ptr) memkind_free(MEMKIND_DAX_KMEM,ptr)
 #endif
 

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -59,7 +59,8 @@
 #define ZMALLOC_LIB "memkind"
 #include <memkind.h>
 #define HAVE_MALLOC_SIZE 1
-#define zmalloc_size(p) memkind_malloc_usable_size(NULL, p)
+extern size_t jemk_malloc_usable_size(void* ptr);
+#define zmalloc_size(p) jemk_malloc_usable_size(p)
 
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>


### PR DESCRIPTION
- call jemalloc functions directly (from jemalloc merged in memkind library)
- since MEMKIND_DEFAULT is just a representation of the standard API of jemalloc,
  shortening the path and avoid unnecessary calls on the memkind layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/140)
<!-- Reviewable:end -->
