### PR TITLE
Add "persistent-memory-variant" option to control allocations on PMEM

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1835,6 +1835,27 @@ jemalloc-bg-thread yes
 # By default Redis use only-dram configuration.
 memory-alloc-policy only-dram
 
+# --- Persistent Memory variants ---
+#
+# HOW IT WORKS?
+#
+# Memory allocator supports allocation on Persistent Memory in two variants:
+#
+# single:    In this variant memory comes from the closest Persistent Memory
+#            NUMA node at the time of allocation. If there is not enough free
+#            memory in this node, to satisfy an allocation request, inactive
+#            pages from this node are moved into the swap space.
+# multiple:  In this variant memory comes from the closest Persistent Memory
+#            NUMA node available at the time of allocation. When there is not
+#            enough free memory in this node, to satisfy an allocation request,
+#            the allocation pattern switches to the next closest persistent NUMA node.
+#            When available space is exhausted in all persistent NUMA nodes -
+#            swap space is used.
+#
+# In both variants, if there is no free memory left in the swap space, an
+# Out of Memory error occurs. By default Redis uses a "single" variant.
+pmem-variant single
+
 # --- THRESHOLD policy ---
 #
 # HOW IT WORKS?

--- a/src/config.c
+++ b/src/config.c
@@ -99,6 +99,12 @@ configEnum memory_alloc_policy_enum[] = {
     {NULL, 0}
 };
 
+configEnum pmem_variant_enum[] = {
+    {"single", PMEM_VARIANT_SINGLE},
+    {"multiple", PMEM_VARIANT_MULTIPLE},
+    {NULL, 0}
+};
+
 configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
@@ -2196,6 +2202,7 @@ standardConfig configs[] = {
     createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, NULL),
     createEnumConfig("memory-alloc-policy", NULL, IMMUTABLE_CONFIG, memory_alloc_policy_enum, server.memory_alloc_policy, MEM_POLICY_ONLY_DRAM, NULL, NULL),
+    createEnumConfig("pmem-variant", NULL, IMMUTABLE_CONFIG, pmem_variant_enum, server.pmem_variant, PMEM_VARIANT_SINGLE, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -41,8 +41,8 @@ static inline size_t absDiff(size_t a, size_t b) {
     return a > b ? (a - b) : (b - a);
 }
 
-/* Initialize the pmem threshold. */
-void pmemThresholdInit(void) {
+/* Initialize the PMEM threshold and variant. */
+void pmemInit(void) {
     switch(server.memory_alloc_policy) {
         case MEM_POLICY_ONLY_DRAM:
             zmalloc_set_threshold(SIZE_MAX);
@@ -58,6 +58,17 @@ void pmemThresholdInit(void) {
         case MEM_POLICY_RATIO:
             zmalloc_set_threshold(server.initial_dynamic_threshold);
             zmalloc_set_pmem_mode();
+            break;
+        default:
+            serverAssert(NULL);
+    }
+
+    switch(server.pmem_variant) {
+        case PMEM_VARIANT_SINGLE:
+            zmalloc_set_pmem_variant_single_mode();
+            break;
+        case PMEM_VARIANT_MULTIPLE:
+            zmalloc_set_pmem_variant_multiple_mode();
             break;
         default:
             serverAssert(NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -2947,7 +2947,7 @@ void initServer(void) {
     scriptingInit(1);
     slowlogInit();
     latencyMonitorInit();
-    pmemThresholdInit();
+    pmemInit();
     dictSetAllocPolicy(server.hashtable_on_dram);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -484,6 +484,10 @@ typedef long long ustime_t; /* microsecond time type. */
 #define MEM_POLICY_RATIO     2          /* use DRAM and PMEM - ratio variant*/
 #define MEM_POLICY_THRESHOLD 3          /* use DRAM and PMEM - threshold variant*/
 
+/* Persistent Memory variants */
+#define PMEM_VARIANT_SINGLE     0
+#define PMEM_VARIANT_MULTIPLE   1
+
 struct RedisModule;
 struct RedisModuleIO;
 struct RedisModuleDigest;
@@ -1349,6 +1353,7 @@ struct redisServer {
     double target_pmem_dram_ratio;            /* Target PMEM/DRAM ratio */
     int ratio_check_period;                   /* Period of checking ratio in Cron*/
     int hashtable_on_dram;                    /* Keep hashtable always on DRAM */
+    int pmem_variant;                         /* PMEM variant (single or multiple) */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];
@@ -2217,7 +2222,7 @@ int dictSdsKeyCompare(void *privdata, const void *key1, const void *key2);
 void dictSdsDestructor(void *privdata, void *val);
 
 /* pmem.c - Handling Persistent Memory */
-void pmemThresholdInit(void);
+void pmemInit(void);
 void adjustPmemThresholdCycle(void);
 
 /* Git SHA1 */

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -107,6 +107,8 @@ size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zmalloc_set_threshold(size_t threshold);
 void zmalloc_set_pmem_mode(void);
+void zmalloc_set_pmem_variant_single_mode(void);
+void zmalloc_set_pmem_variant_multiple_mode(void);
 size_t zmalloc_get_threshold(void);
 void *zmalloc_dram(size_t size);
 void *zcalloc_dram(size_t size);

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -176,6 +176,7 @@ proc start_server {options {code undefined}} {
     set baseconfig "default.conf"
     if {$::pmem_ratio_test} {
         set memory-alloc-policy "ratio"
+        set pmem-variant "single"
         set dram-pmem-ratio "1 3"
         set initial-dynamic-threshold "64"
         set dynamic-threshold-min "24"

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -100,6 +100,7 @@ start_server {tags {"introspection"}} {
             bgsave_cpulist
             dram-pmem-ratio
             memory-alloc-policy
+            pmem-variant
             initial-dynamic-threshold
             dynamic-threshold-min
             dynamic-threshold-max


### PR DESCRIPTION
* when PMEM is used for allocation, by default only single persistent NUMA node
  is used - this is the "single" variant
* to use multiple persitent NUMA nodes a "multiple" variant should be used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/150)
<!-- Reviewable:end -->
