### PR TITLE
Add "pmem-variant" option to control allocations on PMEM

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2074,6 +2074,27 @@ jemalloc-bg-thread yes
 # By default Redis use only-dram configuration.
 memory-alloc-policy only-dram
 
+# --- Persistent Memory variants ---
+#
+# HOW IT WORKS?
+#
+# Memory allocator supports allocation on Persistent Memory in two variants:
+#
+# single:    In this variant memory comes from the closest Persistent Memory
+#            NUMA node at the time of allocation. If there is not enough free
+#            memory in this node, to satisfy an allocation request, inactive
+#            pages from this node are moved into the swap space.
+# multiple:  In this variant memory comes from the closest Persistent Memory
+#            NUMA node available at the time of allocation. When there is not
+#            enough free memory in this node, to satisfy an allocation request,
+#            the allocation pattern switches to the next closest persistent NUMA node.
+#            When available space is exhausted in all persistent NUMA nodes -
+#            swap space is used.
+#
+# In both variants, if there is no free memory left in the swap space, an
+# Out of Memory error occurs. By default Redis uses a "single" variant.
+pmem-variant single
+
 # --- THRESHOLD policy ---
 #
 # HOW IT WORKS?

--- a/src/config.c
+++ b/src/config.c
@@ -99,6 +99,12 @@ configEnum memory_alloc_policy_enum[] = {
     {NULL, 0}
 };
 
+configEnum pmem_variant_enum[] = {
+    {"single", PMEM_VARIANT_SINGLE},
+    {"multiple", PMEM_VARIANT_MULTIPLE},
+    {NULL, 0}
+};
+
 configEnum repl_diskless_load_enum[] = {
     {"disabled", REPL_DISKLESS_LOAD_DISABLED},
     {"on-empty-db", REPL_DISKLESS_LOAD_WHEN_DB_EMPTY},
@@ -2523,6 +2529,7 @@ standardConfig configs[] = {
     createEnumConfig("acl-pubsub-default", NULL, MODIFIABLE_CONFIG, acl_pubsub_default_enum, server.acl_pubsub_default, USER_FLAG_ALLCHANNELS, NULL, NULL),
     createEnumConfig("sanitize-dump-payload", NULL, MODIFIABLE_CONFIG, sanitize_dump_payload_enum, server.sanitize_dump_payload, SANITIZE_DUMP_NO, NULL, NULL),
     createEnumConfig("memory-alloc-policy", NULL, IMMUTABLE_CONFIG, memory_alloc_policy_enum, server.memory_alloc_policy, MEM_POLICY_ONLY_DRAM, NULL, NULL),
+    createEnumConfig("pmem-variant", NULL, IMMUTABLE_CONFIG, pmem_variant_enum, server.pmem_variant, PMEM_VARIANT_SINGLE, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/pmem.c
+++ b/src/pmem.c
@@ -41,8 +41,8 @@ static inline size_t absDiff(size_t a, size_t b) {
     return a > b ? (a - b) : (b - a);
 }
 
-/* Initialize the pmem threshold. */
-void pmemThresholdInit(void) {
+/* Initialize the PMEM threshold and variant. */
+void pmemInit(void) {
     switch(server.memory_alloc_policy) {
         case MEM_POLICY_ONLY_DRAM:
             zmalloc_set_threshold(SIZE_MAX);
@@ -58,6 +58,17 @@ void pmemThresholdInit(void) {
         case MEM_POLICY_RATIO:
             zmalloc_set_threshold(server.initial_dynamic_threshold);
             zmalloc_set_pmem_mode();
+            break;
+        default:
+            serverAssert(NULL);
+    }
+
+    switch(server.pmem_variant) {
+        case PMEM_VARIANT_SINGLE:
+            zmalloc_set_pmem_variant_single_mode();
+            break;
+        case PMEM_VARIANT_MULTIPLE:
+            zmalloc_set_pmem_variant_multiple_mode();
             break;
         default:
             serverAssert(NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -3357,11 +3357,11 @@ void initServer(void) {
     scriptingInit(1);
     slowlogInit();
     latencyMonitorInit();
-    
+
     /* Initialize ACL default password if it exists */
     ACLUpdateDefaultUserPassword(server.requirepass);
 
-    pmemThresholdInit();
+    pmemInit();
     dictSetAllocPolicy(server.hashtable_on_dram);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -540,6 +540,10 @@ typedef enum {
 #define MEM_POLICY_RATIO     2          /* use DRAM and PMEM - ratio variant*/
 #define MEM_POLICY_THRESHOLD 3          /* use DRAM and PMEM - threshold variant*/
 
+/* Persistent Memory variants */
+#define PMEM_VARIANT_SINGLE     0
+#define PMEM_VARIANT_MULTIPLE   1
+
 struct RedisModule;
 struct RedisModuleIO;
 struct RedisModuleDigest;
@@ -1521,6 +1525,7 @@ struct redisServer {
     double target_pmem_dram_ratio;            /* Target PMEM/DRAM ratio */
     int ratio_check_period;                   /* Period of checking ratio in Cron*/
     int hashtable_on_dram;                    /* Keep hashtable always on DRAM */
+    int pmem_variant;                         /* PMEM variant (single or multiple) */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];
@@ -2496,7 +2501,7 @@ int dictSdsKeyCompare(void *privdata, const void *key1, const void *key2);
 void dictSdsDestructor(void *privdata, void *val);
 
 /* pmem.c - Handling Persistent Memory */
-void pmemThresholdInit(void);
+void pmemInit(void);
 void adjustPmemThresholdCycle(void);
 
 /* Git SHA1 */

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -91,12 +91,14 @@ extern void* jemk_calloc(size_t count, size_t size);
 extern void* jemk_realloc(void* ptr, size_t size);
 extern void jemk_free(void* ptr);
 
+static struct memkind* pmem_kind;
+
 #define malloc(size) jemk_malloc(size);
 #define calloc(count,size) jemk_calloc(count,size)
 #define realloc_dram(ptr,size) jemk_realloc(ptr,size)
-#define realloc_pmem(ptr,size) memkind_realloc(MEMKIND_DAX_KMEM,ptr,size)
+#define realloc_pmem(ptr,size) memkind_realloc(pmem_kind,ptr,size)
 #define free_dram(ptr) jemk_free(ptr)
-#define free_pmem(ptr) memkind_free(MEMKIND_DAX_KMEM,ptr)
+#define free_pmem(ptr) memkind_free(pmem_kind,ptr)
 #endif
 
 #define update_zmalloc_dram_stat_alloc(__n) atomicIncr(used_dram_memory,(__n))
@@ -158,6 +160,14 @@ static void *zrealloc_pmem(void *ptr, size_t size) {
 
 size_t zmalloc_used_memory(void) {
     return zmalloc_used_dram_memory();
+}
+
+void zmalloc_set_pmem_variant_single_mode(void) {
+    // Unsupported
+}
+
+void zmalloc_set_pmem_variant_multiple_mode(void) {
+    // Unsupported
 }
 
 static void *ztrymalloc_usable_pmem(size_t size, size_t *usable) {
@@ -233,7 +243,7 @@ static void zfree_usable_pmem(void *ptr, size_t *usable) {
 static int zmalloc_is_pmem(void * ptr) {
     if (memory_variant == MEMORY_ONLY_DRAM) return DRAM_LOCATION;
     struct memkind *temp_kind = memkind_detect_kind(ptr);
-    return (temp_kind == MEMKIND_DAX_KMEM) ? PMEM_LOCATION : DRAM_LOCATION;
+    return (temp_kind == pmem_kind) ? PMEM_LOCATION : DRAM_LOCATION;
 }
 
 size_t zmalloc_used_memory(void) {
@@ -260,7 +270,7 @@ static void zfree_pmem(void *ptr) {
 
 static void *ztrymalloc_usable_pmem(size_t size, size_t *usable) {
     ASSERT_NO_SIZE_OVERFLOW(size);
-    void *ptr = memkind_malloc(MEMKIND_DAX_KMEM, size+PREFIX_SIZE);
+    void *ptr = memkind_malloc(pmem_kind, size+PREFIX_SIZE);
 
     if (!ptr) return NULL;
 #ifdef HAVE_MALLOC_SIZE
@@ -295,7 +305,7 @@ static void *zmalloc_usable_pmem(size_t size, size_t *usable) {
 
 static void *ztrycalloc_usable_pmem(size_t size, size_t *usable) {
     ASSERT_NO_SIZE_OVERFLOW(size);
-    void *ptr = memkind_calloc(MEMKIND_DAX_KMEM, 1, size+PREFIX_SIZE);
+    void *ptr = memkind_calloc(pmem_kind, 1, size+PREFIX_SIZE);
     if (ptr == NULL) return NULL;
 
 #ifdef HAVE_MALLOC_SIZE
@@ -408,6 +418,14 @@ static void zfree_usable_pmem(void *ptr, size_t *usable) {
     update_zmalloc_pmem_stat_free(oldsize+PREFIX_SIZE);
     free_pmem(realptr);
 #endif
+}
+
+void zmalloc_set_pmem_variant_single_mode(void) {
+    pmem_kind = MEMKIND_DAX_KMEM;
+}
+
+void zmalloc_set_pmem_variant_multiple_mode(void) {
+    pmem_kind = MEMKIND_DAX_KMEM_ALL;
 }
 
 #endif

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -136,6 +136,8 @@ size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zmalloc_set_threshold(size_t threshold);
 void zmalloc_set_pmem_mode(void);
+void zmalloc_set_pmem_variant_single_mode(void);
+void zmalloc_set_pmem_variant_multiple_mode(void);
 size_t zmalloc_get_threshold(void);
 void *zmalloc_dram(size_t size);
 void *zcalloc_dram(size_t size);

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -273,6 +273,7 @@ proc start_server {options {code undefined}} {
     set baseconfig "default.conf"
     if {$::pmem_ratio_test} {
         set memory-alloc-policy "ratio"
+        set pmem-variant "single"
         set dram-pmem-ratio "1 3"
         set initial-dynamic-threshold "64"
         set dynamic-threshold-min "24"

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -158,6 +158,7 @@ start_server {tags {"introspection"}} {
             set-proc-title
             dram-pmem-ratio
             memory-alloc-policy
+            pmem-variant
             initial-dynamic-threshold
             dynamic-threshold-min
             dynamic-threshold-max


### PR DESCRIPTION
- when PMEM is used for allocation, by default only single persistent NUMA node
  is used - this is the "single" variant
- to use multiple persitent NUMA nodes a "multiple" variant should be used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/153)
<!-- Reviewable:end -->
