### PR TITLE
Add a separate OOM handler for PMEM

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1548,8 +1548,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 
     serverLogRaw(LL_WARNING|LL_RAW,
 "\n=== REDIS BUG REPORT END. Make sure to include from START to END. ===\n\n"
-"       Please report the crash by opening an issue on github:\n\n"
-"           http://github.com/antirez/redis/issues\n\n"
+"       Please report the crash by opening an issue on github.\n\n"
 "  Suspect RAM error? Use redis-server --test-memory to verify it.\n\n"
 );
 


### PR DESCRIPTION
- this handler first checks if there are any PMEM nodes in the system available for use by Memkind
  and if not - a descriptive error message is printed and allocator is switched to DRAM-only mode
- then the default OOM handler is called

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkeydb/memkeydb/157)
<!-- Reviewable:end -->
